### PR TITLE
Bugfix 05

### DIFF
--- a/src/piminder_monitor/__main__.py
+++ b/src/piminder_monitor/__main__.py
@@ -272,6 +272,15 @@ def runtime():
             for each in range(6):
                 touch.set_led(each, 0)
             exit(0)
+        except OSError:  # In the event of a network availability issue, the other functions can raise this.
+            disp.clear_screen()
+            for each in range(6):
+                touch.set_led(each, 0)
+            disp.print_line(3, "Piminder Monitor")
+            disp.print_line(4, "v%s" % __version__)
+            disp.print_line(7, "Network Fault...\u008B")
+            disp.backlight_set_hue(config["minor_error_color"])
+            sleep(60)
 
 
 if __name__ == "__main__":

--- a/src/piminder_monitor/__main__.py
+++ b/src/piminder_monitor/__main__.py
@@ -10,7 +10,7 @@ Full license and documentation to be found at:
 https://github.com/ZAdamMac/Piminder
 """
 
-__version__ = "1.0.3"
+__version__ = "1.0.5"
 
 import argparse
 import base64
@@ -145,7 +145,7 @@ def delete_message(configuration, list_messages, target_index, ssl_context):
             disp.print_line(1, "HTTP %s" % dict_resp["error"])
             disp.print_line(2, "Fatal, exiting.")
             exit(1)
-        updated_messages = retrieve_messages(configuration, ssl_context)  # Fetching the messages forces a screen update
+    updated_messages = retrieve_messages(configuration, ssl_context)  # Fetching the messages forces a screen update
 
     return updated_messages
 
@@ -167,7 +167,7 @@ def mark_read_message(configuration, list_messages, target_index, ssl_context):
             disp.print_line(1, "HTTP %s" % dict_resp["error"])
             disp.print_line(2, "Fatal, exiting.")
             exit(1)
-        updated_messages = retrieve_messages(configuration, ssl_context)  # fetching the messages forces a screen update.
+    updated_messages = retrieve_messages(configuration, ssl_context)  # fetching the messages forces a screen update.
 
     return updated_messages
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -4,7 +4,7 @@ with open("../README.md", "r") as f:
       long_description = f.read()
 
 setup(name='piminder',
-      version='1.0.3',
+      version='1.0.5',
       description='Piminder is a special network messanging service for status alerts.',
       long_description=long_description,
       author='Zac Adam-MacEwen',


### PR DESCRIPTION
Addresses two problems that could lead to crashes of the monitor application:
- In certain situations (when deleting or marking read at a time when there were no messages in the queue) it is possible for certain human input events to generate a return of an unassigned variable, crashing the application. **New Behaviour:** marking read or deleting messages while the queue is empty will immediately refresh the queue.
- In the event of network issues while the monitor is operating the monitor can crash. **New Behaviour:** an error warning is displayed at the `minor` warning colour scheme and the main operation loop will resume after 60 seconds. This can continue indefinitely until network connectivity is restored (at which point recovery is automatic) or the operator restarts the system. This was issue #6 